### PR TITLE
CB-13170 - final changes and release of post-integration cordova-plugin-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ description: Get JavaScript logs in your native logs.
 
 # cordova-plugin-console
 
+## Deprecated
+
+> This plugin is no longer being worked on as the functionality provided by this plugin is now included in cordova-ios 4.5.0 or greater, and support is already built in to cordova-windows > 5.0.0. You should upgrade your application to use version 2.0.0 of this plugin. It will detect whether or not the plugin is required based on the version of cordova-ios and cordova-windows your app uses.
+> Please file issues for this plugin against their respective platforms (cordova-ios, cordova-windows).
+
+## Description
+
 This plugin is meant to ensure that console.log() is as useful as it can be.
 It adds additional function for iOS, Ubuntu, Windows Phone 8, and Windows. If
 you are happy with how console.log() works for you, then you probably

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-console",
-  "version": "1.0.8-dev",
+  "version": "2.0.0-dev",
   "description": "Cordova Console Plugin",
   "cordova": {
     "id": "cordova-plugin-console",
@@ -39,8 +39,9 @@
   "license": "Apache-2.0",
   "engines": {
     "cordovaDependencies": {
-      "2.0.0": {
-        "cordova": ">100"
+      ">=2.0.0": {
+        "cordova-ios": "<4.5.0",
+        "cordova-windows": "<=5.0.0"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-console"
-      version="1.0.8-dev">
+      version="2.0.0-dev">
 
     <name>Console</name>
     <description>Cordova Console Plugin</description>
@@ -28,6 +28,11 @@
     <keywords>cordova,console</keywords>
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-console.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320644</issue>
+
+    <engines>
+        <engine name="cordova-windows" version="<=5.0.0"/>
+        <engine name="cordova-ios" version="<4.5.0"/>
+    </engines>
 
     <!-- ios -->
     <platform name="ios">


### PR DESCRIPTION
### Platforms affected

cordova-ios, cordova-windows

### What does this PR do?

Prevent installation of this plugin on cordova-ios >= 4.5.0, and cordova-windows > 5.0.0

### What testing has been done on this change?

Added the plugin on different platform versions for the affected platforms.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
